### PR TITLE
Migrate to sbt-assembly 13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,3 @@
-import AssemblyKeys._
-
-assemblySettings
-
 name := "template-scala-parallel-recommendation"
 
 organization := "io.prediction"

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")


### PR DESCRIPTION
It looks like there are not much to change, so I tought maybe upgrading it could be a good idea.

Migration documentation:
https://github.com/sbt/sbt-assembly/blob/master/Migration.md
